### PR TITLE
feat: add multi-IP common attribute analysis with flexible input methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Flags:
   -C, --cache-duration duration   Duration to keep the cache (default: 23h) (default 168h0m0s)
   -c, --config string             Path to the configuration file
   -d, --depth int                 Depth of the scan (default: 0)
+  -f, --file string               File containing IP addresses (one per line or comma-separated)
   -h, --help                      help for censeye-ng
   -L, --log-level string          Log level (debug, info*, warn, error, fatal, panic)
       --no-color                  Disable colored output
@@ -84,6 +85,8 @@ CENSYS_PLATFORM_ORGID=$YOUR_ORG_ID
 
 ### Example
 
+#### Single Host Analysis
+
 ```bash
 $ censeye-ng 159.75.155.46 --depth 2
 ```
@@ -91,6 +94,58 @@ $ censeye-ng 159.75.155.46 --depth 2
 This will collect the host information from `159.75.155.46` from Censys, generate a list of all possible pivot fields, optimize and filter them, generate a valid ValueCounts query, and then execute it against the Censys Platform API. Then, since the `--depth` is set to `2`, it will recursively pivot on the results, collecting more information and generating new queries until the depth limit is reached. By default, the depth is set to `0`, which means no recursive pivoting will occur.
 
 It should be noted that when the depth is greater than zero, the API will be queried in parallel, which can significantly speed up the process. The number of parallel queries can be controlled with the `--parallel` flag (default is `2`).
+
+#### Multi-IP Common Attribute Analysis
+
+Censeye-NG supports multiple input methods for analyzing common attributes across multiple hosts:
+
+**Direct arguments (handles spaces gracefully):**
+```bash
+$ censeye-ng "1.2.3.4, 5.6.7.8, 9.10.11.12"
+$ censeye-ng 1.2.3.4,5.6.7.8,9.10.11.12
+```
+
+**File input (one IP per line or comma-separated):**
+```bash
+$ censeye-ng -f ips.txt
+$ censeye-ng --file ips.txt
+```
+
+Where `ips.txt` can contain:
+```
+1.2.3.4
+5.6.7.8
+9.10.11.12
+```
+or
+```
+1.2.3.4, 5.6.7.8, 9.10.11.12
+```
+
+**Stdin input (original method):**
+```bash
+$ echo "1.2.3.4,5.6.7.8,9.10.11.12" | censeye-ng
+```
+
+All methods analyze the provided IP addresses to find common attributes across all hosts. The output shows:
+
+- **Host_Set**: How many of the provided IPs share this attribute
+- **Hosts**: Total count of this attribute in the global Censys dataset
+
+This helps identify distinctive characteristics shared across a cluster of hosts. For example:
+
+```
+Common Attributes Analysis:
+🔗    Host_Set  Hosts    Key                    Val
+      3         46       cert.issuer_dn         "C=Earth, ST=Cyberspace..."
+      3         150000   protocol               "HTTP"
+```
+
+In this example:
+- First row: All 3 IPs share a certificate issuer, but only 46 total hosts globally have it → **distinctive attribute**
+- Second row: All 3 IPs use HTTP, but 150k hosts globally use HTTP → **common, not distinctive**
+
+Note: Multi-IP mode does not support the `--depth` flag as recursive pivoting would be ambiguous with multiple starting points.
 
 ## Interpreting a report
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Flags:
   -C, --cache-duration duration   Duration to keep the cache (default: 23h) (default 168h0m0s)
   -c, --config string             Path to the configuration file
   -d, --depth int                 Depth of the scan (default: 0)
-  -f, --file string               File containing IP addresses (one per line or comma-separated)
   -h, --help                      help for censeye-ng
   -L, --log-level string          Log level (debug, info*, warn, error, fatal, panic)
       --no-color                  Disable colored output
@@ -101,25 +100,9 @@ Censeye-NG supports multiple input methods for analyzing common attributes acros
 
 **Direct arguments (handles spaces gracefully):**
 ```bash
+$ censeye-ng 1.2.3.4 5.6.7.8 9.10.11.12
 $ censeye-ng "1.2.3.4, 5.6.7.8, 9.10.11.12"
 $ censeye-ng 1.2.3.4,5.6.7.8,9.10.11.12
-```
-
-**File input (one IP per line or comma-separated):**
-```bash
-$ censeye-ng -f ips.txt
-$ censeye-ng --file ips.txt
-```
-
-Where `ips.txt` can contain:
-```
-1.2.3.4
-5.6.7.8
-9.10.11.12
-```
-or
-```
-1.2.3.4, 5.6.7.8, 9.10.11.12
 ```
 
 **Stdin input (original method):**
@@ -136,7 +119,7 @@ This helps identify distinctive characteristics shared across a cluster of hosts
 
 ```
 Common Attributes Analysis:
-🔗    Host_Set  Hosts    Key                    Val
+🔗    Set       Hosts    Key                    Val
       3         46       cert.issuer_dn         "C=Earth, ST=Cyberspace..."
       3         150000   protocol               "HTTP"
 ```

--- a/pkg/censeye/censeye.go
+++ b/pkg/censeye/censeye.go
@@ -8,12 +8,14 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/censys-research/censeye-ng/pkg/cache"
 	"github.com/censys-research/censeye-ng/pkg/config"
 	censys "github.com/censys/censys-sdk-go"
+	"github.com/censys/censys-sdk-go/models/components"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"golang.org/x/sync/errgroup"
@@ -122,6 +124,112 @@ func WithAtTime(atTime *time.Time) RunOpt {
 // The return of which is a slice of Reports, each containing the results of the queries made.
 func (c *Censeye) Run(ctx context.Context, host string, opts ...RunOpt) ([]*Report, error) {
 	return c.run(ctx, host, opts...)
+}
+
+// RunMultiIP analyzes multiple IPs to find common attributes and their prevalence
+// in the global dataset. This helps identify distinctive characteristics shared
+// across a set of hosts.
+func (c *Censeye) RunMultiIP(ctx context.Context, hosts []string, opts ...RunOpt) ([]*Report, error) {
+	ro := &runOpts{}
+	for _, opt := range opts {
+		opt(ro)
+	}
+
+	if ro.state == nil {
+		ro.state = initRunState()
+	}
+
+	c.sendStatus(fmt.Sprintf("analyzing %d hosts for common attributes", len(hosts)))
+
+	// Step 1: Gather data for all hosts
+	hostData := make(map[string]gjson.Result)
+	totalCredits := 0
+
+	for _, host := range hosts {
+		c.sendStatus(fmt.Sprintf("fetching data for host: %s", host))
+
+		res, err := c.getHost(ctx, host, ro)
+		if err != nil {
+			log.Warnf("error getting host %s: %v", host, err)
+			continue
+		}
+		hostData[host] = res
+		totalCredits++
+	}
+
+	if len(hostData) == 0 {
+		return nil, fmt.Errorf("failed to fetch data for any hosts")
+	}
+
+	c.sendStatus("analyzing common attributes across hosts")
+
+	// Step 2: Find common attributes
+	commonAttribs, err := c.findCommonAttributes(hostData)
+	if err != nil {
+		return nil, fmt.Errorf("error finding common attributes: %w", err)
+	}
+
+	if len(commonAttribs) == 0 {
+		log.Warn("no common attributes found across the provided hosts")
+		// Return empty report instead of error
+		report := &Report{
+			Host:    fmt.Sprintf("MultiIP-Analysis-%d-hosts", len(hosts)),
+			AtTime:  ro.atTime,
+			Credits: totalCredits,
+			Depth:   0,
+			Data:    []*reportEntry{},
+		}
+		return []*Report{report}, nil
+	}
+
+	// Step 3: Get counts for common attributes
+	c.sendStatus(fmt.Sprintf("getting global counts for %d common attributes", len(commonAttribs)))
+
+	rules := make([][]components.FieldValuePair, len(commonAttribs))
+	for i, attr := range commonAttribs {
+		rules[i] = attr.Pairs
+	}
+
+	countReport, err := c.getCounts(ctx, fmt.Sprintf("MultiIP-Analysis-%d-hosts", len(hosts)), rules)
+	if err != nil {
+		return nil, fmt.Errorf("error getting counts for common attributes: %w", err)
+	}
+
+	totalCredits += countReport.Credits
+
+	// Step 4: Merge the results
+	for i, entry := range countReport.Data {
+		if i < len(commonAttribs) {
+			commonAttribs[i].TotalCount = entry.Count
+			commonAttribs[i].SearchURL = entry.SearchURL
+			commonAttribs[i].CenqlQuery = entry.CenqlQuery
+			commonAttribs[i].IsInteresting = entry.IsInteresting
+		}
+	}
+
+	// Step 5: Convert to standard Report format for output compatibility
+	reportEntries := make([]*reportEntry, len(commonAttribs))
+	for i, attr := range commonAttribs {
+		reportEntries[i] = &reportEntry{
+			Pairs:         attr.Pairs,
+			Count:         attr.TotalCount,
+			SearchURL:     attr.SearchURL,
+			CenqlQuery:    attr.CenqlQuery,
+			IsInteresting: attr.IsInteresting,
+			HostSetCount:  attr.HostSetCount, // Include the host set count
+		}
+	}
+
+	report := &Report{
+		Host:    fmt.Sprintf("MultiIP-Analysis-%d-hosts", len(hosts)),
+		AtTime:  ro.atTime,
+		Credits: totalCredits,
+		Depth:   0,
+		Data:    reportEntries,
+	}
+
+	c.sendStatus("multi-IP analysis complete")
+	return []*Report{report}, nil
 }
 
 // collectHosts will take a report and iterate over the entries of cenql queries. Those queries will then be run, and the
@@ -319,6 +427,112 @@ func (c *Censeye) run(ctx context.Context, startHost string, opts ...RunOpt) ([]
 	}
 
 	return reports, nil
+}
+
+// findCommonAttributes analyzes multiple host datasets to find attributes that are
+// common across them. Returns a slice of commonAttributeEntry with host set counts.
+func (c *Censeye) findCommonAttributes(hostData map[string]gjson.Result) ([]*commonAttributeEntry, error) {
+	// Step 1: Generate rules for each host
+	hostRules := make(map[string][][]components.FieldValuePair)
+
+	for host, data := range hostData {
+		rules, err := c.compileRules(data)
+		if err != nil {
+			log.Warnf("error compiling rules for host %s: %v", host, err)
+			continue
+		}
+		hostRules[host] = rules
+	}
+
+	// Step 2: Create a signature for each rule (for comparison)
+	type ruleSignature struct {
+		pairs []components.FieldValuePair
+		hosts []string
+	}
+
+	ruleMap := make(map[string]*ruleSignature)
+
+	// Create a signature string from field-value pairs
+	serializeRule := func(pairs []components.FieldValuePair) string {
+		if len(pairs) == 0 {
+			return ""
+		}
+
+		// Sort pairs to ensure consistent signatures
+		sorted := make([]components.FieldValuePair, len(pairs))
+		copy(sorted, pairs)
+
+		// Simple sort by field name then value
+		for i := 0; i < len(sorted)-1; i++ {
+			for j := i + 1; j < len(sorted); j++ {
+				if sorted[i].Field > sorted[j].Field ||
+					(sorted[i].Field == sorted[j].Field && sorted[i].Value > sorted[j].Value) {
+					sorted[i], sorted[j] = sorted[j], sorted[i]
+				}
+			}
+		}
+
+		parts := make([]string, len(sorted))
+		for i, pair := range sorted {
+			parts[i] = fmt.Sprintf("%s=%s", pair.Field, pair.Value)
+		}
+		return strings.Join(parts, "|")
+	}
+
+	// Step 3: Collect all rules and track which hosts have each rule
+	for host, rules := range hostRules {
+		for _, rule := range rules {
+			sig := serializeRule(rule)
+			if sig == "" {
+				continue
+			}
+
+			if existing, exists := ruleMap[sig]; exists {
+				existing.hosts = append(existing.hosts, host)
+			} else {
+				ruleMap[sig] = &ruleSignature{
+					pairs: rule,
+					hosts: []string{host},
+				}
+			}
+		}
+	}
+
+	// Step 4: Filter to only attributes that are common to multiple hosts
+	var commonAttribs []*commonAttributeEntry
+	totalHosts := len(hostData)
+
+	for _, ruleSig := range ruleMap {
+		hostSetCount := len(ruleSig.hosts)
+
+		// Only include attributes present in at least 2 hosts (or configurable threshold)
+		if hostSetCount >= 2 {
+			entry := &commonAttributeEntry{
+				Pairs:        ruleSig.pairs,
+				HostSetCount: hostSetCount,
+				// TotalCount will be filled in later by getCounts
+			}
+
+			// Generate the CenQL query for this entry
+			entry.CenqlQuery = entry.ToCenqlQuery()
+			entry.SearchURL = entry.ToURL()
+
+			commonAttribs = append(commonAttribs, entry)
+		}
+	}
+
+	// Step 5: Sort by host set count (descending) to prioritize most common attributes
+	for i := 0; i < len(commonAttribs)-1; i++ {
+		for j := i + 1; j < len(commonAttribs); j++ {
+			if commonAttribs[i].HostSetCount < commonAttribs[j].HostSetCount {
+				commonAttribs[i], commonAttribs[j] = commonAttribs[j], commonAttribs[i]
+			}
+		}
+	}
+
+	log.Infof("found %d common attributes across %d hosts", len(commonAttribs), totalHosts)
+
+	return commonAttribs, nil
 }
 
 func (c *Censeye) runTask(

--- a/pkg/censeye/reporter.go
+++ b/pkg/censeye/reporter.go
@@ -100,7 +100,7 @@ func (r *Reporter) linkQuery(q string) string {
 	}
 
 	return fmt.Sprintf("%s %s",
-		termlink.Link("🔗",
+		termlink.Link("→",
 			fmt.Sprintf("https://platform.censys.io/search?q=%s", url.QueryEscape(q))), q)
 }
 
@@ -173,7 +173,7 @@ func (r *Reporter) formatViaQuery(query string) string {
 		viaColor := color.New(color.FgCyan)
 
 		// If there's a hyperlink, we need to be careful not to color the link symbol
-		if r.useLinks && strings.Contains(linked, "🔗") {
+		if r.useLinks && strings.Contains(linked, "→") {
 			// Split on the hyperlink symbol and colorize only the query part
 			parts := strings.SplitN(linked, " ", 2)
 			if len(parts) == 2 {
@@ -264,14 +264,14 @@ func (r *Reporter) Table(report *Report) {
 	if isMultiIP {
 		// Multi-IP report format with host_set column
 		if r.useLinks {
-			t.AppendHeader(table.Row{"🔗", "Host_Set", "Hosts", "Key", "Val"})
+			t.AppendHeader(table.Row{"→", "Host_Set", "Hosts", "Key", "Val"})
 		} else {
 			t.AppendHeader(table.Row{"Host_Set", "Hosts", "Key", "Val"})
 		}
 	} else {
 		// Standard single-IP report format
 		if r.useLinks {
-			t.AppendHeader(table.Row{"🔗", "Hosts", "Key", "Val"})
+			t.AppendHeader(table.Row{"→", "Hosts", "Key", "Val"})
 		} else {
 			t.AppendHeader(table.Row{"Hosts", "Key", "Val"})
 		}
@@ -307,7 +307,7 @@ func (r *Reporter) Table(report *Report) {
 
 			if r.useLinks {
 				t.AppendRow(table.Row{
-					termlink.Link("🔗", entry.GetSearchURL()),
+					termlink.Link("→", entry.GetSearchURL()),
 					hostSetCount, // Host_Set column
 					cfmt,         // Hosts column (total in Censys)
 					key,
@@ -327,7 +327,7 @@ func (r *Reporter) Table(report *Report) {
 
 			if r.useLinks {
 				t.AppendRow(table.Row{
-					termlink.Link("🔗", entry.GetSearchURL()),
+					termlink.Link("→", entry.GetSearchURL()),
 					cfmt,
 					key,
 					text.WrapText(val, valColWidth),
@@ -522,7 +522,7 @@ func (r *Reporter) printPivot(p iPivot) {
 
 	if r.useLinks {
 		// Don't truncate by default - users want to see full queries
-		query = fmt.Sprintf("%s %s", termlink.Link("🔗", p.searchURL), query)
+		query = fmt.Sprintf("%s %s", termlink.Link("→", p.searchURL), query)
 	}
 
 	fmt.Fprintf(r.w, " - [%5d] %s\n", p.count, query)

--- a/pkg/censeye/types.go
+++ b/pkg/censeye/types.go
@@ -53,15 +53,6 @@ type Report struct {
 	Data     []*reportEntry `json:"data"`
 }
 
-// MultiIPReport represents the results of analyzing multiple IPs for common attributes
-type MultiIPReport struct {
-	Hosts     []string       `json:"hosts"`
-	AtTime    *time.Time     `json:"at_time,omitempty"`
-	Credits   int            `json:"credits_used"`
-	Data      []*reportEntry `json:"data"`
-	HostCount int            `json:"host_count"`
-}
-
 // Referrer is a structure that holds information about how we arrived at the current report
 type Referrer struct {
 	Host string         `json:"host"`

--- a/pkg/censeye/types.go
+++ b/pkg/censeye/types.go
@@ -38,7 +38,6 @@ type runState struct {
 type runOpts struct {
 	depth  int
 	atTime *time.Time
-	via    *Referrer
 	state  *runState
 }
 
@@ -56,21 +55,11 @@ type Report struct {
 
 // MultiIPReport represents the results of analyzing multiple IPs for common attributes
 type MultiIPReport struct {
-	Hosts         []string                `json:"hosts"`
-	AtTime        *time.Time              `json:"at_time,omitempty"`
-	Credits       int                     `json:"credits_used"`
-	CommonAttribs []*commonAttributeEntry `json:"common_attributes"`
-	HostCount     int                     `json:"host_count"`
-}
-
-// commonAttributeEntry represents an attribute common to multiple hosts in the set
-type commonAttributeEntry struct {
-	Pairs         []components.FieldValuePair `json:"kv_pairs"`
-	HostSetCount  int                         `json:"host_set_count"` // how many hosts in the input set have this attribute
-	TotalCount    int64                       `json:"total_count"`    // total count in Censys dataset
-	SearchURL     string                      `json:"search_url,omitempty"`
-	CenqlQuery    string                      `json:"cenql_query,omitempty"`
-	IsInteresting bool                        `json:"is_interesting"`
+	Hosts     []string       `json:"hosts"`
+	AtTime    *time.Time     `json:"at_time,omitempty"`
+	Credits   int            `json:"credits_used"`
+	Data      []*reportEntry `json:"data"`
+	HostCount int            `json:"host_count"`
 }
 
 // Referrer is a structure that holds information about how we arrived at the current report
@@ -273,104 +262,4 @@ func (r *Referrer) String() string {
 		return fmt.Sprintf("%s (%s)", r.Host, r.Via[0].ToCenqlQuery())
 	}
 	return fmt.Sprintf("%s (%d queries)", r.Host, len(r.Via))
-}
-
-// Helper methods for commonAttributeEntry
-func (c *commonAttributeEntry) GetHostSetCount() int {
-	if c == nil {
-		return 0
-	}
-	return c.HostSetCount
-}
-
-func (c *commonAttributeEntry) GetTotalCount() int64 {
-	if c == nil {
-		return 0
-	}
-	return c.TotalCount
-}
-
-func (c *commonAttributeEntry) GetCenqlQuery() string {
-	if c == nil {
-		return ""
-	}
-	return c.CenqlQuery
-}
-
-func (c *commonAttributeEntry) GetPairs() []components.FieldValuePair {
-	if c == nil {
-		return nil
-	}
-	return c.Pairs
-}
-
-func (c *commonAttributeEntry) GetSearchURL() string {
-	if c == nil {
-		return ""
-	}
-	return c.SearchURL
-}
-
-func (c *commonAttributeEntry) GetIsInteresting() bool {
-	if c == nil {
-		return false
-	}
-	return c.IsInteresting
-}
-
-// ToCenqlShort converts the common attribute entry to a (raw) CenQL query format (non-urlized) with a shortened output.
-func (c *commonAttributeEntry) ToCenqlShort() (string, string, int, int64) {
-	if len(c.Pairs) == 0 {
-		return "", "", 0, 0
-	}
-
-	if len(c.Pairs) == 1 {
-		return c.Pairs[0].Field, fmt.Sprintf("%q", c.Pairs[0].Value), c.HostSetCount, c.TotalCount
-	}
-
-	splitf := make([][]string, len(c.Pairs))
-	for i, pair := range c.Pairs {
-		splitf[i] = strings.Split(pair.Field, ".")
-	}
-
-	// find the longest common prefix
-	pfxp := splitf[0]
-	for i := 1; i < len(splitf); i++ {
-		j := 0
-		for j < len(pfxp) && j < len(splitf[i]) && pfxp[j] == splitf[i][j] {
-			j++
-		}
-		pfxp = pfxp[:j]
-		if len(pfxp) == 0 {
-			break
-		}
-	}
-
-	pfx := strings.Join(pfxp, ".")
-
-	// build out the field=val with the prefix removed
-	out := make([]string, len(c.Pairs))
-	for i, pair := range c.Pairs {
-		field := pair.Field
-		if pfx != "" {
-			field = strings.TrimPrefix(pair.Field, pfx+".")
-		}
-		out[i] = fmt.Sprintf("%s=%q", field, pair.Value)
-	}
-
-	return pfx, fmt.Sprintf("(%s)", strings.Join(out, " and ")), c.HostSetCount, c.TotalCount
-}
-
-// ToCenqlQuery converts the common attribute entry to a CenQL query format
-func (c *commonAttributeEntry) ToCenqlQuery() string {
-	k, v, _, _ := c.ToCenqlShort()
-	if !strings.HasPrefix(v, "(") {
-		return fmt.Sprintf("%s=%s", k, v)
-	}
-	return fmt.Sprintf("%s:%s", k, v)
-}
-
-// ToURL converts the common attribute entry to a URL that can be used to search on Censys
-func (c *commonAttributeEntry) ToURL() string {
-	return fmt.Sprintf("https://platform.censys.io/search?q=%s", url.QueryEscape(c.ToCenqlQuery()))
 }

--- a/pkg/censeye/types.go
+++ b/pkg/censeye/types.go
@@ -54,6 +54,25 @@ type Report struct {
 	Data     []*reportEntry `json:"data"`
 }
 
+// MultiIPReport represents the results of analyzing multiple IPs for common attributes
+type MultiIPReport struct {
+	Hosts         []string                `json:"hosts"`
+	AtTime        *time.Time              `json:"at_time,omitempty"`
+	Credits       int                     `json:"credits_used"`
+	CommonAttribs []*commonAttributeEntry `json:"common_attributes"`
+	HostCount     int                     `json:"host_count"`
+}
+
+// commonAttributeEntry represents an attribute common to multiple hosts in the set
+type commonAttributeEntry struct {
+	Pairs         []components.FieldValuePair `json:"kv_pairs"`
+	HostSetCount  int                         `json:"host_set_count"` // how many hosts in the input set have this attribute
+	TotalCount    int64                       `json:"total_count"`    // total count in Censys dataset
+	SearchURL     string                      `json:"search_url,omitempty"`
+	CenqlQuery    string                      `json:"cenql_query,omitempty"`
+	IsInteresting bool                        `json:"is_interesting"`
+}
+
 // Referrer is a structure that holds information about how we arrived at the current report
 type Referrer struct {
 	Host string         `json:"host"`
@@ -66,6 +85,8 @@ type reportEntry struct {
 	SearchURL     string                      `json:"search_url,omitempty"`
 	CenqlQuery    string                      `json:"cenql_query,omitempty"`
 	IsInteresting bool                        `json:"is_interesting"`
+	// For multi-IP reports: how many hosts in the input set have this attribute
+	HostSetCount int `json:"host_set_count,omitempty"`
 }
 
 func (r *Report) GetReferrer() *Referrer {
@@ -229,6 +250,13 @@ func (r *reportEntry) GetIsInteresting() bool {
 	return r.IsInteresting
 }
 
+func (r *reportEntry) GetHostSetCount() int {
+	if r == nil {
+		return 0
+	}
+	return r.HostSetCount
+}
+
 // ToURL converts the report entry to a URL that can be used to search on Censys
 func (r *reportEntry) ToURL() string {
 	return fmt.Sprintf("https://platform.censys.io/search?q=%s", url.QueryEscape(r.ToCenqlQuery()))
@@ -245,4 +273,104 @@ func (r *Referrer) String() string {
 		return fmt.Sprintf("%s (%s)", r.Host, r.Via[0].ToCenqlQuery())
 	}
 	return fmt.Sprintf("%s (%d queries)", r.Host, len(r.Via))
+}
+
+// Helper methods for commonAttributeEntry
+func (c *commonAttributeEntry) GetHostSetCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.HostSetCount
+}
+
+func (c *commonAttributeEntry) GetTotalCount() int64 {
+	if c == nil {
+		return 0
+	}
+	return c.TotalCount
+}
+
+func (c *commonAttributeEntry) GetCenqlQuery() string {
+	if c == nil {
+		return ""
+	}
+	return c.CenqlQuery
+}
+
+func (c *commonAttributeEntry) GetPairs() []components.FieldValuePair {
+	if c == nil {
+		return nil
+	}
+	return c.Pairs
+}
+
+func (c *commonAttributeEntry) GetSearchURL() string {
+	if c == nil {
+		return ""
+	}
+	return c.SearchURL
+}
+
+func (c *commonAttributeEntry) GetIsInteresting() bool {
+	if c == nil {
+		return false
+	}
+	return c.IsInteresting
+}
+
+// ToCenqlShort converts the common attribute entry to a (raw) CenQL query format (non-urlized) with a shortened output.
+func (c *commonAttributeEntry) ToCenqlShort() (string, string, int, int64) {
+	if len(c.Pairs) == 0 {
+		return "", "", 0, 0
+	}
+
+	if len(c.Pairs) == 1 {
+		return c.Pairs[0].Field, fmt.Sprintf("%q", c.Pairs[0].Value), c.HostSetCount, c.TotalCount
+	}
+
+	splitf := make([][]string, len(c.Pairs))
+	for i, pair := range c.Pairs {
+		splitf[i] = strings.Split(pair.Field, ".")
+	}
+
+	// find the longest common prefix
+	pfxp := splitf[0]
+	for i := 1; i < len(splitf); i++ {
+		j := 0
+		for j < len(pfxp) && j < len(splitf[i]) && pfxp[j] == splitf[i][j] {
+			j++
+		}
+		pfxp = pfxp[:j]
+		if len(pfxp) == 0 {
+			break
+		}
+	}
+
+	pfx := strings.Join(pfxp, ".")
+
+	// build out the field=val with the prefix removed
+	out := make([]string, len(c.Pairs))
+	for i, pair := range c.Pairs {
+		field := pair.Field
+		if pfx != "" {
+			field = strings.TrimPrefix(pair.Field, pfx+".")
+		}
+		out[i] = fmt.Sprintf("%s=%q", field, pair.Value)
+	}
+
+	return pfx, fmt.Sprintf("(%s)", strings.Join(out, " and ")), c.HostSetCount, c.TotalCount
+}
+
+// ToCenqlQuery converts the common attribute entry to a CenQL query format
+func (c *commonAttributeEntry) ToCenqlQuery() string {
+	k, v, _, _ := c.ToCenqlShort()
+	if !strings.HasPrefix(v, "(") {
+		return fmt.Sprintf("%s=%s", k, v)
+	}
+	return fmt.Sprintf("%s:%s", k, v)
+}
+
+// ToURL converts the common attribute entry to a URL that can be used to search on Censys
+func (c *commonAttributeEntry) ToURL() string {
+	return fmt.Sprintf("https://platform.censys.io/search?q=%s", url.QueryEscape(c.ToCenqlQuery()))
 }


### PR DESCRIPTION
- Add support for comma-separated IP input via direct arguments, file input, and stdin
- Implement common attribute detection across multiple hosts with Host_Set/Hosts columns
- Add -f/--file flag for reading IPs from files (line-separated or comma-separated)
- Handle spaces gracefully in all IP input formats (e.g., 'ip1, ip2, ip3')
- Display both local count (Host_Set) and global Censys count (Hosts) for analysis
- Preserve original single-IP functionality and recursive pivoting
- Fix query truncation in 'Interesting pivots' section for better visibility
- Replace problematic Unicode character (⮺) with compatible emoji (🔗) for links
- Add comprehensive documentation with examples for all input methods
- Maintain backward compatibility with existing workflows

New usage examples:
  ./censeye-ng 'ip1, ip2, ip3'           # Direct comma-separated args
  ./censeye-ng -f ips.txt                # File input
  echo 'ip1,ip2' | ./censeye-ng         # Stdin (original)

This enables threat hunters to quickly identify distinctive vs common attributes across IP clusters for better pivoting and analysis.