### PR TITLE
Show all matching via queries per host in pivot tree

### DIFF
--- a/pkg/censeye/reporter.go
+++ b/pkg/censeye/reporter.go
@@ -237,6 +237,16 @@ func (r *Reporter) buildTreeFromNodes(t treeprint.Tree, nodes []*PivotNode) {
 			host := r.linkHost(node.IP)
 			hostWithTags := r.formatHostWithTags(host, node.Labels, node.Threats)
 			branch := t.AddBranch(hostWithTags)
+
+			// if this host was found via more than one of the parent's queries,
+			// list the additional matching queries beneath it.
+			if len(node.AlsoVia) > 0 {
+				alsoBranch := branch.AddBranch("⋮ also via:")
+				for _, q := range node.AlsoVia {
+					alsoBranch.AddNode(r.formatViaQuery(q))
+				}
+			}
+
 			r.buildTreeFromNodes(branch, node.Children)
 		}
 	}
@@ -359,6 +369,7 @@ type PivotNode struct {
 	IP       string       `json:"ip,omitempty"`
 	Depth    int          `json:"depth,omitempty"`
 	Via      string       `json:"via,omitempty"`
+	AlsoVia  []string     `json:"also_via,omitempty"`
 	Labels   []string     `json:"labels,omitempty"`
 	Threats  []string     `json:"threats,omitempty"`
 	Children []*PivotNode `json:"children,omitempty"`
@@ -374,6 +385,7 @@ func (r *Reporter) CreatePivotTree(reports []*Report) []*PivotNode {
 		ip      string
 		depth   int
 		via     string
+		alsoVia []string
 		parent  string
 		labels  []string
 		threats []string
@@ -384,10 +396,16 @@ func (r *Reporter) CreatePivotTree(reports []*Report) []*PivotNode {
 		parent := ""
 		depth := 0
 		via := ""
+		var alsoVia []string
 
 		if ref := rep.GetReferrer(); ref != nil {
 			parent = ref.GetHost()
 			via = ref.GetVia().GetCenqlQuery()
+			// the host may have matched more than one of the parent's queries;
+			// the first is used for grouping, the rest are surfaced per-host.
+			for _, entry := range ref.GetAllVia()[min(1, len(ref.GetAllVia())):] {
+				alsoVia = append(alsoVia, entry.GetCenqlQuery())
+			}
 			if parentNode, ok := nodes[parent]; ok {
 				depth = parentNode.depth + 1
 			}
@@ -397,6 +415,7 @@ func (r *Reporter) CreatePivotTree(reports []*Report) []*PivotNode {
 			ip:      rep.Host,
 			depth:   depth,
 			via:     via,
+			alsoVia: alsoVia,
 			parent:  parent,
 			labels:  rep.Labels,
 			threats: rep.Threats,
@@ -434,6 +453,7 @@ func (r *Reporter) CreatePivotTree(reports []*Report) []*PivotNode {
 				ipNodes = append(ipNodes, &PivotNode{
 					IP:       child.ip,
 					Depth:    child.depth,
+					AlsoVia:  child.alsoVia,
 					Labels:   child.labels,
 					Threats:  child.threats,
 					Children: build(child.ip),
@@ -458,6 +478,7 @@ func (r *Reporter) CreatePivotTree(reports []*Report) []*PivotNode {
 				groupChildren = append(groupChildren, &PivotNode{
 					IP:       child.ip,
 					Depth:    child.depth,
+					AlsoVia:  child.alsoVia,
 					Labels:   child.labels,
 					Threats:  child.threats,
 					Children: build(child.ip),

--- a/pkg/censeye/reporter.go
+++ b/pkg/censeye/reporter.go
@@ -231,6 +231,13 @@ func (r *Reporter) buildTreeFromNodes(t treeprint.Tree, nodes []*PivotNode) {
 			formattedQuery := r.formatViaQuery(node.Via)
 			label := fmt.Sprintf("via: %s", formattedQuery)
 			viaBranch := t.AddBranch(label)
+
+			// queries shared by every host in this group are hoisted here so
+			// they aren't repeated under each host.
+			if len(node.AlsoVia) > 0 {
+				r.addAlsoViaBranch(viaBranch, fmt.Sprintf("⋮ also via (all %d hosts):", len(node.Children)), node.AlsoVia)
+			}
+
 			r.buildTreeFromNodes(viaBranch, node.Children)
 		} else {
 			// This is an IP node
@@ -238,17 +245,25 @@ func (r *Reporter) buildTreeFromNodes(t treeprint.Tree, nodes []*PivotNode) {
 			hostWithTags := r.formatHostWithTags(host, node.Labels, node.Threats)
 			branch := t.AddBranch(hostWithTags)
 
-			// if this host was found via more than one of the parent's queries,
-			// list the additional matching queries beneath it.
-			if len(node.AlsoVia) > 0 {
-				alsoBranch := branch.AddBranch("⋮ also via:")
-				for _, q := range node.AlsoVia {
-					alsoBranch.AddNode(r.formatViaQuery(q))
-				}
-			}
+			// any queries unique to this host (i.e. not shared by the whole
+			// group and hoisted to the parent) are listed beneath it.
+			r.addAlsoViaBranch(branch, "⋮ also via:", node.AlsoVia)
 
 			r.buildTreeFromNodes(branch, node.Children)
 		}
+	}
+}
+
+// addAlsoViaBranch adds a labeled branch listing the given "also via" queries.
+// It is a no-op when there are no queries to show.
+func (r *Reporter) addAlsoViaBranch(t treeprint.Tree, label string, queries []string) {
+	if len(queries) == 0 {
+		return
+	}
+
+	b := t.AddBranch(label)
+	for _, q := range queries {
+		b.AddNode(r.formatViaQuery(q))
 	}
 }
 
@@ -484,8 +499,24 @@ func (r *Reporter) CreatePivotTree(reports []*Report) []*PivotNode {
 					Children: build(child.ip),
 				})
 			}
+
+			// hoist "also via" queries shared by every host in the group up to
+			// the group node, and strip them from each host so only its unique
+			// queries remain listed beneath it.
+			shared := commonAlsoVia(groupChildren)
+			if len(shared) > 0 {
+				sharedSet := make(map[string]struct{}, len(shared))
+				for _, q := range shared {
+					sharedSet[q] = struct{}{}
+				}
+				for _, gc := range groupChildren {
+					gc.AlsoVia = filterOutQueries(gc.AlsoVia, sharedSet)
+				}
+			}
+
 			viaNodes = append(viaNodes, &PivotNode{
 				Via:      via,
+				AlsoVia:  shared,
 				Children: groupChildren,
 			})
 		}
@@ -505,6 +536,52 @@ func (r *Reporter) CreatePivotTree(reports []*Report) []*PivotNode {
 	}
 
 	return jsonRoots
+}
+
+// commonAlsoVia returns the "also via" queries present on every host in the
+// group, preserving the order they appear on the first host. It returns nil
+// for groups smaller than two hosts, where there is nothing to collapse.
+func commonAlsoVia(children []*PivotNode) []string {
+	if len(children) < 2 {
+		return nil
+	}
+
+	counts := make(map[string]int)
+	for _, c := range children {
+		seen := make(map[string]struct{})
+		for _, q := range c.AlsoVia {
+			if _, ok := seen[q]; ok {
+				continue // dedup within a single host
+			}
+			seen[q] = struct{}{}
+			counts[q]++
+		}
+	}
+
+	var common []string
+	seen := make(map[string]struct{})
+	for _, q := range children[0].AlsoVia {
+		if _, ok := seen[q]; ok {
+			continue
+		}
+		seen[q] = struct{}{}
+		if counts[q] == len(children) {
+			common = append(common, q)
+		}
+	}
+
+	return common
+}
+
+// filterOutQueries returns items with any element in remove dropped, preserving order.
+func filterOutQueries(items []string, remove map[string]struct{}) []string {
+	var out []string
+	for _, it := range items {
+		if _, ok := remove[it]; !ok {
+			out = append(out, it)
+		}
+	}
+	return out
 }
 
 func (r *Reporter) printPivot(p iPivot) {

--- a/pkg/censeye/reporter_alsovia_test.go
+++ b/pkg/censeye/reporter_alsovia_test.go
@@ -54,3 +54,40 @@ func TestPivotTreeShowsAlsoVia(t *testing.T) {
 		t.Fatalf("expected third matching query (body_hash) in output, got:\n%s", out)
 	}
 }
+
+func TestPivotTreeHoistsSharedAlsoVia(t *testing.T) {
+	primary := entry("host.services.cert.fingerprint_sha256", "0750f2")
+	subjectDN := entry("host.services.cert.parsed.subject_dn", "CN=chessroyale.app")
+	commonName := entry("host.services.cert.parsed.subject.common_name", "chessroyale.app")
+	bodyHash := entry("host.services.endpoints.http.body_hash_sha256", "4a66f6")
+
+	reports := []*Report{
+		{Host: "1.1.1.1", Depth: 0},
+		// three hosts share {subjectDN, commonName}; one also has bodyHash.
+		{Host: "3.124.61.92", Depth: 1, Referrer: &Referrer{Host: "1.1.1.1", Via: []*reportEntry{primary, subjectDN, commonName}}},
+		{Host: "3.125.201.74", Depth: 1, Referrer: &Referrer{Host: "1.1.1.1", Via: []*reportEntry{primary, subjectDN, commonName}}},
+		{Host: "35.159.75.206", Depth: 1, Referrer: &Referrer{Host: "1.1.1.1", Via: []*reportEntry{primary, subjectDN, commonName, bodyHash}}},
+	}
+
+	var buf bytes.Buffer
+	r := NewReporter(&buf, "no-colors", "no-links")
+	r.PivotTree(reports)
+
+	out := buf.String()
+	t.Logf("\n%s", out)
+
+	// the shared queries should be hoisted once under the group node.
+	if !strings.Contains(out, "also via (all 3 hosts):") {
+		t.Fatalf("expected hoisted shared-via section, got:\n%s", out)
+	}
+	if strings.Count(out, "common_name=\"chessroyale.app\"") != 1 {
+		t.Fatalf("expected shared common_name query listed exactly once, got:\n%s", out)
+	}
+	if strings.Count(out, "subject_dn=\"CN=chessroyale.app\"") != 1 {
+		t.Fatalf("expected shared subject_dn query listed exactly once, got:\n%s", out)
+	}
+	// the body_hash query is unique to one host and must remain under it.
+	if strings.Count(out, "body_hash_sha256=\"4a66f6\"") != 1 {
+		t.Fatalf("expected unique body_hash query listed once under its host, got:\n%s", out)
+	}
+}

--- a/pkg/censeye/reporter_alsovia_test.go
+++ b/pkg/censeye/reporter_alsovia_test.go
@@ -1,0 +1,56 @@
+package censeye
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/censys/censys-sdk-go/models/components"
+)
+
+func entry(field, value string) *reportEntry {
+	e := &reportEntry{
+		Pairs: []components.FieldValuePair{{Field: field, Value: value}},
+	}
+	e.CenqlQuery = e.ToCenqlQuery()
+	return e
+}
+
+func TestPivotTreeShowsAlsoVia(t *testing.T) {
+	certVia := entry("host.services.cert.parsed.subject_dn", "O=Organization")
+	ja4Via := entry("host.services.ja4tscan.fingerprint", "65160_2-4-8-1-3_1424_7_1-2-4-8-16")
+	bodyVia := entry("host.services.http.body_hash", "sha256:deadbeef")
+
+	reports := []*Report{
+		{Host: "113.45.185.225", Depth: 0},
+		// child matched by three of the parent's queries; first is primary.
+		{
+			Host:     "115.159.25.200",
+			Depth:    1,
+			Referrer: &Referrer{Host: "113.45.185.225", Via: []*reportEntry{certVia, ja4Via, bodyVia}},
+		},
+		// sibling matched by only the primary query.
+		{
+			Host:     "101.34.83.47",
+			Depth:    1,
+			Referrer: &Referrer{Host: "113.45.185.225", Via: []*reportEntry{certVia}},
+		},
+	}
+
+	var buf bytes.Buffer
+	r := NewReporter(&buf, "no-colors", "no-links")
+	r.PivotTree(reports)
+
+	out := buf.String()
+	t.Logf("\n%s", out)
+
+	if !strings.Contains(out, "also via:") {
+		t.Fatalf("expected 'also via:' section in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "ja4tscan.fingerprint") {
+		t.Fatalf("expected second matching query (ja4tscan) in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "body_hash") {
+		t.Fatalf("expected third matching query (body_hash) in output, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Problem

At depth > 0, the pivot tree showed each host under only **one** \`via\` query, even when the host matched several. The multi-\`via\` data was already captured but dropped at render time:

- \`collectHosts\` (censeye.go:178-190) appends every matching query from a parent into \`Referrer.Via\` (a \`[]*reportEntry\`).
- The per-host **table** output already lists them all ("All matching queries:").
- But \`CreatePivotTree\` (reporter.go) stored only \`Via[0]\` and grouped by that single string, silently discarding the rest.

## Fix

Purely in \`reporter.go\` — the recursion engine is untouched:

1. Add \`AlsoVia []string\` to \`PivotNode\` (also serialized as \`also_via\` in JSON output).
2. Carry every via after the primary (\`GetAllVia()[1:]\`, guarded for the empty case) into the tree node.
3. Render the extras under each host as a nested \`⋮ also via:\` branch, reusing the existing \`formatViaQuery\` link/color formatting.

Hosts matched by a single query are unchanged (no extra branch).

## Example

\`\`\`
Pivot Tree:
113.45.185.225 (depth 0)
└── via: host.services.cert.parsed.subject_dn="O=Organization"
    ├── 101.34.83.47
    └── 115.159.25.200
        └── ⋮ also via:
            ├── host.services.ja4tscan.fingerprint="65160_2-4-8-1-3_1424_7_1-2-4-8-16"
            └── host.services.http.body_hash="sha256:deadbeef"
\`\`\`

## Notes

- Adds \`pkg/censeye/reporter_alsovia_test.go\` (first test in the package) as a regression guard. Full suite passes.
- Separate pre-existing limitation, not addressed here: the global \`queryChecked\` dedup in \`collectHosts\` means if two sibling parents share a query, only the first runs it, so a host's cross-parent matches aren't all attributed.